### PR TITLE
[김일규] step-7 예외 처리

### DIFF
--- a/src/main/java/softeer2nd/Main.java
+++ b/src/main/java/softeer2nd/Main.java
@@ -11,34 +11,75 @@ public class Main {
     private static final String START_COMMAND = "start";
     private static final String FINISH_COMMAND = "end";
     private static final String MOVE_COMMAND = "move";
+    private static boolean started = false;
 
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
         Board board = new Board();
         ChessGame chessGame = new ChessGame(board);
         ChessView chessView = new ChessView(board);
+        boolean isFinish = false;
 
-        while (true) {
+        while (!isFinish) {
             System.out.print("> ");
             String input = scanner.nextLine().trim();
+            String[] command = getCommand(input);
 
-            if (input.equals(START_COMMAND)) {
-                board.initialize();
+            switch (command[0]) {
+                case START_COMMAND:
+                    doStartCommand(board);
+                    break;
+                case MOVE_COMMAND:
+                    doMoveCommand(chessGame, command);
+                    break;
+                case FINISH_COMMAND:
+                    isFinish = true;
+                    break;
+                default:
+                    invalidCommand();
             }
-            if (input.startsWith(MOVE_COMMAND)) {
-                String[] strings = input.split(" ");
-                try {
-                    chessGame.movePiece(new Position(strings[1]), new Position(strings[2]));
-                } catch (Exception e) {
-                    System.out.println(e.getMessage());
-                }
+            if(started) {
+                System.out.println(chessView.showBoard());
             }
-
-            if (input.equals(FINISH_COMMAND)) {
-                break;
-            }
-            System.out.println(chessView.showBoard());
         }
         scanner.close();
+    }
+
+
+    private static String[] getCommand(String input) {
+        return input.split(" ");
+    }
+
+    private static void doStartCommand(Board board) {
+        board.initialize();
+        started = true;
+    }
+
+    private static void doMoveCommand(ChessGame chessGame, String[] command) {
+        if(!checkCanMoveCommand(command)) {
+            return;
+        }
+        try {
+            chessGame.movePiece(new Position(command[1]), new Position(command[2]));
+        } catch (RuntimeException e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    private static boolean checkCanMoveCommand(String[] command) {
+        if(!started) {
+            System.out.println("체스가 시작되지 않았습니다");
+            return false;
+        }
+
+        if(command.length != 3) {
+            System.out.println("move 명령어의 인수가 너무 많습니다");
+            return false;
+        }
+        return true;
+    }
+
+    private static void invalidCommand() {
+        System.out.println("해석할 수 없는 명령입니다.");
     }
 }

--- a/src/main/java/softeer2nd/Main.java
+++ b/src/main/java/softeer2nd/Main.java
@@ -22,19 +22,22 @@ public class Main {
             System.out.print("> ");
             String input = scanner.nextLine().trim();
 
-            if(input.equals(START_COMMAND)) {
+            if (input.equals(START_COMMAND)) {
                 board.initialize();
             }
-
-            if(input.startsWith(MOVE_COMMAND)) {
+            if (input.startsWith(MOVE_COMMAND)) {
                 String[] strings = input.split(" ");
-                chessGame.movePiece(new Position(strings[1]), new Position(strings[2]));
+                try {
+                    chessGame.movePiece(new Position(strings[1]), new Position(strings[2]));
+                } catch (Exception e) {
+                    System.out.println(e.getMessage());
+                }
             }
 
-            if(input.equals(FINISH_COMMAND)) {
+            if (input.equals(FINISH_COMMAND)) {
                 break;
             }
-            chessView.showBoard();
+            System.out.println(chessView.showBoard());
         }
         scanner.close();
     }

--- a/src/main/java/softeer2nd/chess/ChessGame.java
+++ b/src/main/java/softeer2nd/chess/ChessGame.java
@@ -2,6 +2,7 @@ package softeer2nd.chess;
 
 import softeer2nd.chess.board.Board;
 import softeer2nd.chess.exception.IllegalMovePositionException;
+import softeer2nd.chess.exception.IllegalTurnException;
 import softeer2nd.chess.pieces.Direction;
 import softeer2nd.chess.pieces.Piece;
 import softeer2nd.chess.pieces.Piece.Color;
@@ -14,9 +15,11 @@ import java.util.stream.IntStream;
 import static softeer2nd.chess.pieces.PieceFactory.*;
 
 public class ChessGame {
+    private Color turnColor;
     private final Board board;
 
     public ChessGame(Board board) {
+        this.turnColor =  Color.WHITE;
         this.board = board;
     }
 
@@ -25,10 +28,12 @@ public class ChessGame {
 
         verifyPathPositions(targetPos, curPiece);
         verifyTargetPosition(targetPos, curPiece);
+        verifyTurn(sourcePos);
 
         curPiece.changePosition(targetPos);
         board.putPiece(targetPos, curPiece);
         board.putPiece(sourcePos, createBlank(sourcePos));
+        changeTurn();
     }
 
     public double calculatePoint(Color color) {
@@ -48,6 +53,20 @@ public class ChessGame {
         return point;
     }
 
+
+    private void changeTurn() {
+        Color nextTurnColor = Color.WHITE;
+        if(this.turnColor.equals(Color.WHITE)) {
+            nextTurnColor = Color.BLACK;
+        }
+        this.turnColor = nextTurnColor;
+    }
+
+    private void verifyTurn(Position sourcePos) {
+        if(!board.findPiece(sourcePos).isColor(turnColor)) {
+            throw new IllegalTurnException();
+        }
+    }
 
     private void verifyPathPositions(Position targetPos, Piece sourcePiece) {
         for (Position pos : sourcePiece.getMovePath(targetPos)) {

--- a/src/main/java/softeer2nd/chess/ChessGame.java
+++ b/src/main/java/softeer2nd/chess/ChessGame.java
@@ -19,7 +19,7 @@ public class ChessGame {
     private final Board board;
 
     public ChessGame(Board board) {
-        this.turnColor =  Color.WHITE;
+        this.turnColor = Color.WHITE;
         this.board = board;
     }
 
@@ -56,14 +56,14 @@ public class ChessGame {
 
     private void changeTurn() {
         Color nextTurnColor = Color.WHITE;
-        if(this.turnColor.equals(Color.WHITE)) {
+        if (this.turnColor.equals(Color.WHITE)) {
             nextTurnColor = Color.BLACK;
         }
         this.turnColor = nextTurnColor;
     }
 
     private void verifyTurn(Position sourcePos) {
-        if(!board.findPiece(sourcePos).isColor(turnColor)) {
+        if (!board.findPiece(sourcePos).isColor(turnColor)) {
             throw new IllegalTurnException();
         }
     }
@@ -81,7 +81,7 @@ public class ChessGame {
         if (board.findPiece(targetPos).isColor(sourcePiece.getColor())) {
             throw new IllegalMovePositionException();
         }
-        if(sourcePiece.isType(Type.PAWN)) {
+        if (sourcePiece.isType(Type.PAWN)) {
             checkPawnMoveRule(targetPos, sourcePiece);
         }
     }
@@ -94,10 +94,10 @@ public class ChessGame {
 
     private void checkPawnMoveRule(Position targetPos, Piece sourcePiece) {
         Direction moveDirection = sourcePiece.getMoveDirection(targetPos);
-        if(Direction.linearDirection().contains(moveDirection)){
+        if (Direction.linearDirection().contains(moveDirection)) {
             checkPawnMoveLinearRule(targetPos);
         }
-        if(Direction.diagonalDirection().contains(moveDirection)) {
+        if (Direction.diagonalDirection().contains(moveDirection)) {
             checkPawnMoveDiagonalRule(targetPos, sourcePiece);
         }
     }
@@ -117,7 +117,7 @@ public class ChessGame {
 
     public static Color getEnemyColor(Piece sourcePiece) {
         Color enemyColor = Color.WHITE;
-        if(sourcePiece.isColor(Color.WHITE)) {
+        if (sourcePiece.isColor(Color.WHITE)) {
             enemyColor = Color.BLACK;
         }
         return enemyColor;

--- a/src/main/java/softeer2nd/chess/board/Board.java
+++ b/src/main/java/softeer2nd/chess/board/Board.java
@@ -1,5 +1,6 @@
 package softeer2nd.chess.board;
 
+import softeer2nd.chess.exception.MissingKingException;
 import softeer2nd.chess.pieces.Piece;
 import softeer2nd.chess.pieces.Piece.Type;
 import softeer2nd.chess.pieces.Piece.Color;
@@ -9,66 +10,80 @@ import java.util.*;
 
 import static softeer2nd.utils.StringUtils.appendNewLine;
 
-
 public class Board {
     public static final int SIDE_LENGTH = 8;
 
-    private final List<Rank> board = new ArrayList<>();
+    private final List<Rank> ranks = new ArrayList<>();
 
     public void initializeEmpty() {
-        board.clear();
+        ranks.clear();
         for (int rankNum = 0; rankNum < SIDE_LENGTH; rankNum++) {
-            board.add(Rank.getBlankRank(rankNum));
+            ranks.add(Rank.getBlankRank(rankNum));
         }
     }
 
     public void initialize() {
-        board.clear();
-        board.add(Rank.getEdgeRank(Color.WHITE));
-        board.add(Rank.getPawnRank(Color.WHITE));
+        ranks.clear();
+        ranks.add(Rank.getEdgeRank(Color.WHITE));
+        ranks.add(Rank.getPawnRank(Color.WHITE));
         for (int rankNum = 3; rankNum < SIDE_LENGTH - 1; rankNum++) {
-            board.add(Rank.getBlankRank(rankNum));
+            ranks.add(Rank.getBlankRank(rankNum));
         }
-        board.add(Rank.getPawnRank(Color.BLACK));
-        board.add(Rank.getEdgeRank(Color.BLACK));
+        ranks.add(Rank.getPawnRank(Color.BLACK));
+        ranks.add(Rank.getEdgeRank(Color.BLACK));
     }
 
     public Piece findPiece(Position position) {
-        return board.get(position.getRankNum())
+        return ranks.get(position.getRankNum())
                 .get(position.getFileNum());
     }
 
     public void putPiece(Position position, Piece piece) {
-        board.get(position.getRankNum())
+        ranks.get(position.getRankNum())
                 .set(position.getFileNum(), piece);
+    }
+
+    public Position getKingPositionByColor(Color color) {
+        Rank kingRank = ranks.stream()
+                .filter(r -> r.countSpecificPieces(color, Type.KING) > 0)
+                .findFirst()
+                .orElseThrow(MissingKingException::new);
+
+        return kingRank.getKingPosition();
     }
 
     public List<Piece> getPiecesInFileByColor(int fileNum, Color color) {
         List<Piece> pieces = new ArrayList<>();
         for (int rankNum = 0; rankNum < SIDE_LENGTH; rankNum++) {
-            Piece curPiece = board.get(rankNum).get(fileNum);
+            Piece curPiece = ranks.get(rankNum).get(fileNum);
             if (curPiece.isColor(color)) {
-                pieces.add(board.get(rankNum).get(fileNum));
+                pieces.add(ranks.get(rankNum).get(fileNum));
             }
         }
         return pieces;
     }
 
+    public List<Piece> getPiecesByColor(Color color) {
+        List<Piece> pieces = new ArrayList<>();
+        ranks.forEach(r -> pieces.addAll(r.getPiecesByColor(color)));
+        return pieces;
+    }
+
     public int countTotalPieces() {
-        return board.stream()
+        return ranks.stream()
                 .mapToInt(Rank::countTotalPieces)
                 .sum();
     }
 
     public int countPiecesByTypeAndColor(Color color, Type type) {
-        return board.stream()
+        return ranks.stream()
                 .mapToInt(r -> r.countSpecificPieces(color, type))
                 .sum();
     }
 
     public List<Piece> getSortedPiecesByPointAndColor(Color color) {
         List<Piece> pieces = new ArrayList<>();
-        board.forEach(r -> pieces.addAll(r.getPiecesByColor(color)));
+        ranks.forEach(r -> pieces.addAll(r.getPiecesByColor(color)));
         pieces.sort(Comparator.reverseOrder());
         return pieces;
     }
@@ -77,7 +92,7 @@ public class Board {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         for (int rankNum = Board.SIDE_LENGTH - 1; rankNum >= 0; rankNum--) {
-            sb.append(appendNewLine(board.get(rankNum).showRank()));
+            sb.append(appendNewLine(ranks.get(rankNum).showRank()));
         }
         return sb.toString();
     }

--- a/src/main/java/softeer2nd/chess/board/Board.java
+++ b/src/main/java/softeer2nd/chess/board/Board.java
@@ -45,9 +45,9 @@ public class Board {
 
     public List<Piece> getPiecesInFileByColor(int fileNum, Color color) {
         List<Piece> pieces = new ArrayList<>();
-        for (int rankNum = 0; rankNum < SIDE_LENGTH; rankNum++){
+        for (int rankNum = 0; rankNum < SIDE_LENGTH; rankNum++) {
             Piece curPiece = board.get(rankNum).get(fileNum);
-            if(curPiece.isColor(color)){
+            if (curPiece.isColor(color)) {
                 pieces.add(board.get(rankNum).get(fileNum));
             }
         }

--- a/src/main/java/softeer2nd/chess/board/Rank.java
+++ b/src/main/java/softeer2nd/chess/board/Rank.java
@@ -1,5 +1,6 @@
 package softeer2nd.chess.board;
 
+import softeer2nd.chess.exception.MissingKingException;
 import softeer2nd.chess.pieces.Piece.Color;
 import softeer2nd.chess.pieces.Piece.Type;
 import softeer2nd.chess.pieces.Piece;
@@ -15,12 +16,13 @@ import static softeer2nd.chess.board.Board.SIDE_LENGTH;
 public class Rank {
     private final List<Piece> pieces = new ArrayList<>(SIDE_LENGTH);
 
-    private Rank() {}
+    private Rank() {
+    }
 
     public static Rank getEdgeRank(Color color) {
         Rank rank = new Rank();
         int rankNum = 0;
-        if(color.equals(Color.BLACK)) {
+        if (color.equals(Color.BLACK)) {
             rankNum = 7;
         }
 
@@ -34,7 +36,7 @@ public class Rank {
     public static Rank getPawnRank(Color color) {
         Rank rank = new Rank();
         int rankNum = 1;
-        if(color.equals(Color.BLACK)) {
+        if (color.equals(Color.BLACK)) {
             rankNum = 6;
         }
 
@@ -46,7 +48,7 @@ public class Rank {
 
     public static Rank getBlankRank(int rankNum) {
         Rank rank = new Rank();
-        for (int fileNum = 0; fileNum < SIDE_LENGTH; fileNum++){
+        for (int fileNum = 0; fileNum < SIDE_LENGTH; fileNum++) {
             rank.add(PieceFactory.createBlank(new Position(fileNum, rankNum)));
         }
         return rank;
@@ -76,7 +78,16 @@ public class Rank {
                 .count();
     }
 
-    public List<Piece> getPiecesByColor(Piece.Color color) {
+    public Position getKingPosition() {
+        for (Piece piece : pieces) {
+            if (piece.isType(Type.KING)) {
+                return piece.getPosition();
+            }
+        }
+        throw new MissingKingException();
+    }
+
+    public List<Piece> getPiecesByColor(Color color) {
         return pieces.stream()
                 .filter(p -> p.isColor(color))
                 .collect(Collectors.toList());

--- a/src/main/java/softeer2nd/chess/exception/CheckmateException.java
+++ b/src/main/java/softeer2nd/chess/exception/CheckmateException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class CheckmateException extends RuntimeException{
+    private static final String MESSAGE = "체크메이트 입니다.";
+
+    public CheckmateException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/IllegalInputException.java
+++ b/src/main/java/softeer2nd/chess/exception/IllegalInputException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class IllegalInputException extends RuntimeException{
+    private static final String MESSAGE = "입력을 해석할 수 없습니다";
+
+    public IllegalInputException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/IllegalMovePieceException.java
+++ b/src/main/java/softeer2nd/chess/exception/IllegalMovePieceException.java
@@ -1,9 +1,0 @@
-package softeer2nd.chess.exception;
-
-public class IllegalMovePieceException extends RuntimeException {
-    private static final String MESSAGE = "해당 기물은 움직일 수 없습니다";
-
-    public IllegalMovePieceException() {
-        super(MESSAGE);
-    }
-}

--- a/src/main/java/softeer2nd/chess/exception/IllegalMovePositionException.java
+++ b/src/main/java/softeer2nd/chess/exception/IllegalMovePositionException.java
@@ -1,7 +1,8 @@
 package softeer2nd.chess.exception;
 
-public class IllegalMovePositionException extends RuntimeException{
+public class IllegalMovePositionException extends RuntimeException {
     private static final String MESSAGE = "해당 위치로 움직일 수 없습니다";
+
     public IllegalMovePositionException() {
         super(MESSAGE);
     }

--- a/src/main/java/softeer2nd/chess/exception/IllegalTurnException.java
+++ b/src/main/java/softeer2nd/chess/exception/IllegalTurnException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class IllegalTurnException extends RuntimeException {
+    private static final String MESSAGE = "턴이 아닙니다";
+
+    public IllegalTurnException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/MissingKingException.java
+++ b/src/main/java/softeer2nd/chess/exception/MissingKingException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class MissingKingException extends RuntimeException {
+    private static final String MESSAGE = "킹이 존재하지 않습니다.";
+
+    public MissingKingException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/MoveBlankException.java
+++ b/src/main/java/softeer2nd/chess/exception/MoveBlankException.java
@@ -1,0 +1,9 @@
+package softeer2nd.chess.exception;
+
+public class MoveBlankException extends RuntimeException {
+    private static final String MESSAGE = "빈 공간은 움직일 수 없습니다";
+
+    public MoveBlankException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/softeer2nd/chess/exception/OutOfBoardException.java
+++ b/src/main/java/softeer2nd/chess/exception/OutOfBoardException.java
@@ -1,6 +1,6 @@
 package softeer2nd.chess.exception;
 
-public class OutOfBoardException extends RuntimeException{
+public class OutOfBoardException extends RuntimeException {
     private static final String MESSAGE = "체스판 범위를 벗어난 위치입니다";
 
     public OutOfBoardException() {

--- a/src/main/java/softeer2nd/chess/exception/WrongPositionException.java
+++ b/src/main/java/softeer2nd/chess/exception/WrongPositionException.java
@@ -1,9 +1,0 @@
-package softeer2nd.chess.exception;
-
-public class WrongPositionException extends RuntimeException {
-    private static final String MESSAGE = "입력한 위치를 해석할 수 없습니다";
-
-    public WrongPositionException() {
-        super(MESSAGE);
-    }
-}

--- a/src/main/java/softeer2nd/chess/pieces/Blank.java
+++ b/src/main/java/softeer2nd/chess/pieces/Blank.java
@@ -1,6 +1,6 @@
 package softeer2nd.chess.pieces;
 
-import softeer2nd.chess.exception.IllegalMovePieceException;
+import softeer2nd.chess.exception.MoveBlankException;
 
 import java.util.List;
 
@@ -11,11 +11,11 @@ public class Blank extends Piece {
 
     @Override
     protected List<Direction> getMovableDirection() {
-        throw new IllegalMovePieceException();
+        throw new MoveBlankException();
     }
 
     @Override
     protected boolean isMovablePositionByDirection(Position targetPos, Direction direction) {
-        throw new IllegalMovePieceException();
+        throw new MoveBlankException();
     }
 }

--- a/src/main/java/softeer2nd/chess/pieces/Piece.java
+++ b/src/main/java/softeer2nd/chess/pieces/Piece.java
@@ -6,7 +6,7 @@ import softeer2nd.chess.exception.IllegalMovePositionException;
 import java.util.*;
 
 
-public abstract class Piece implements Comparable<Piece>{
+public abstract class Piece implements Comparable<Piece> {
     private final Color color;
     private final Type type;
     private final Position position;
@@ -30,7 +30,7 @@ public abstract class Piece implements Comparable<Piece>{
     }
 
     public char getRepresentation() {
-        if(color.equals(Color.BLACK)) return type.getBlackRepresentation();
+        if (color.equals(Color.BLACK)) return type.getBlackRepresentation();
         return type.getWhiteRepresentation();
     }
 
@@ -54,7 +54,7 @@ public abstract class Piece implements Comparable<Piece>{
             Position curPos = new Position(
                     getPosition().getFileNum() + direction.getXDegree() * moveCount,
                     getPosition().getRankNum() + direction.getYDegree() * moveCount);
-            if(curPos.equals(targetPos)) {
+            if (curPos.equals(targetPos)) {
                 break;
             }
             path.add(curPos);

--- a/src/main/java/softeer2nd/chess/pieces/PieceFactory.java
+++ b/src/main/java/softeer2nd/chess/pieces/PieceFactory.java
@@ -8,7 +8,7 @@ import static softeer2nd.chess.pieces.Piece.*;
 public class PieceFactory {
     public static Piece createNotBlank(Color color, Type type, Position position) {
         switch (type) {
-            case KING :
+            case KING:
                 return new King(color, position);
             case QUEEN:
                 return new Queen(color, position);

--- a/src/main/java/softeer2nd/utils/PositionUtils.java
+++ b/src/main/java/softeer2nd/utils/PositionUtils.java
@@ -1,8 +1,8 @@
 package softeer2nd.utils;
 
 import softeer2nd.chess.board.Board;
+import softeer2nd.chess.exception.IllegalInputException;
 import softeer2nd.chess.exception.OutOfBoardException;
-import softeer2nd.chess.exception.WrongPositionException;
 
 public class PositionUtils {
     private PositionUtils() {
@@ -10,7 +10,7 @@ public class PositionUtils {
 
     public static int getFileNumFromPosition(String position) {
         if (position.length() != 2 || !Character.isAlphabetic(position.charAt(0))) {
-            throw new WrongPositionException();
+            throw new IllegalInputException();
         }
         int num = Character.toLowerCase(position.charAt(0)) - 'a';
         verifyNumberInBoard(num);
@@ -19,7 +19,7 @@ public class PositionUtils {
 
     public static int getRankNumFromPosition(String position) {
         if (position.length() != 2 || !Character.isDigit(position.charAt(1))) {
-            throw new WrongPositionException();
+            throw new IllegalInputException();
         }
         int num = Character.getNumericValue(position.charAt(1)) - 1;
         verifyNumberInBoard(num);

--- a/src/test/java/softeer2nd/chess/ChessGameTest.java
+++ b/src/test/java/softeer2nd/chess/ChessGameTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import softeer2nd.chess.board.Board;
 import softeer2nd.chess.exception.IllegalMovePieceException;
 import softeer2nd.chess.exception.IllegalMovePositionException;
+import softeer2nd.chess.exception.IllegalTurnException;
 import softeer2nd.chess.pieces.Piece;
 import softeer2nd.chess.pieces.Piece.Type;
 import softeer2nd.chess.pieces.Piece.Color;
@@ -30,7 +31,6 @@ class ChessGameTest {
     @Nested
     @DisplayName("movePiece method")
     class MovePiece {
-
         @Nested
         @DisplayName("기물이 공백이라면")
         class IsPieceBlank {
@@ -50,6 +50,39 @@ class ChessGameTest {
         @Nested
         @DisplayName("기물이 공백이 아니라면")
         class IsPieceNotBlank {
+            @Nested
+            @DisplayName("올바른 이동일 때 턴이 흰색이라면")
+            class IsTurnWhite {
+                @Test
+                @DisplayName("검은색 기물을 움직이면 IllegalTurnException이 발생한다")
+                void cannotMoveBlackPiece() {
+                    //given
+                    board.initialize();
+
+                    //when
+                    //then
+                    assertThatThrownBy(() -> chessGame.movePiece(new Position("a7"), new Position("a6")))
+                            .isInstanceOf(IllegalTurnException.class);
+                }
+            }
+
+            @Nested
+            @DisplayName("올바른 이동일 때 턴이 검은색이라면")
+            class IsTurnBlack {
+                @Test
+                @DisplayName("흰색 기물을 움직이면 IllegalTurnException이 발생한다")
+                void cannotMoveWhitePiece() {
+                    //given
+                    board.initialize();
+                    chessGame.movePiece(new Position("a2"), new Position("a3"));
+
+                    //when
+                    //then
+                    assertThatThrownBy(() -> chessGame.movePiece(new Position("b2"), new Position("b3")))
+                            .isInstanceOf(IllegalTurnException.class);
+                }
+            }
+
             @Nested
             @DisplayName("목적지가 기물이 이동할 수 있는 위치라면")
             class IsPieceCanMoveToPosition {

--- a/src/test/java/softeer2nd/chess/ChessGameTest.java
+++ b/src/test/java/softeer2nd/chess/ChessGameTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import softeer2nd.chess.board.Board;
-import softeer2nd.chess.exception.IllegalMovePieceException;
+import softeer2nd.chess.exception.CheckmateException;
+import softeer2nd.chess.exception.MoveBlankException;
 import softeer2nd.chess.exception.IllegalMovePositionException;
 import softeer2nd.chess.exception.IllegalTurnException;
 import softeer2nd.chess.pieces.Piece;
@@ -35,15 +36,15 @@ class ChessGameTest {
         @DisplayName("기물이 공백이라면")
         class IsPieceBlank {
             @Test
-            @DisplayName("IllegalMovePieceException이 발생한다")
-            void throwIllegalMovePieceException() {
+            @DisplayName("MoveBlankException이 발생한다")
+            void throwMoveBlankException() {
                 //given
                 board.initializeEmpty();
 
                 //when
                 //then
                 assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a2")))
-                        .isInstanceOf(IllegalMovePieceException.class);
+                        .isInstanceOf(MoveBlankException.class);
             }
         }
 
@@ -84,163 +85,8 @@ class ChessGameTest {
             }
 
             @Nested
-            @DisplayName("목적지가 기물이 이동할 수 있는 위치라면")
-            class IsPieceCanMoveToPosition {
-                @Nested
-                @DisplayName("목적지에 같은 팀 기물이 존재한다면")
-                class IsSameTeamPieceInTargetPosition {
-                    @Test
-                    @DisplayName("IllegalMovePositionException이 발생한다")
-                    void throwIllegalMovePositionException() {
-                        //given
-                        board.initializeEmpty();
-                        addPiece(Color.WHITE, Type.QUEEN, "a1");
-                        addPiece(Color.WHITE, Type.BISHOP, "a8");
-
-                        //when
-                        //then
-
-                        assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a8")))
-                                .isInstanceOf(IllegalMovePositionException.class);
-                    }
-                }
-
-                @Nested
-                @DisplayName("목적지에 같은 팀 기물이 존재하지 않다면")
-                class IsSameTeamPieceNotInTargetPosition {
-
-                    @Nested
-                    @DisplayName("목적지까지 경로에 다른 기물이 존재한다면")
-                    class IsPieceInPath {
-                        @Test
-                        @DisplayName("IllegalMovePositionException이 발생한다")
-                        void throwIllegalMovePositionException() {
-                            //given
-                            board.initializeEmpty();
-                            addPiece(Color.WHITE, Type.QUEEN, "a1");
-                            addPiece(Color.BLACK, Type.PAWN, "a4");
-
-                            //when
-                            //then
-                            assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a8")))
-                                    .isInstanceOf(IllegalMovePositionException.class);
-                        }
-                    }
-
-                    @Nested
-                    @DisplayName("목적지까지 경로에 다른 기물이 존재하지 않는다면")
-                    class IsPieceNotInpath {
-                        @Nested
-                        @DisplayName("기물이 폰이라면")
-                        class IsPiecePawn {
-                            @Nested
-                            @DisplayName("이동이 직선이라면")
-                            class IsMoveLinear {
-                                @Nested
-                                @DisplayName("목적지에 기물이 있다면")
-                                class IsPieceInPosition {
-                                    @Test
-                                    @DisplayName("IllegalMovePositionException이 발생한다")
-                                    void throwIllegalMovePositionException() {
-                                        //given
-                                        board.initializeEmpty();
-                                        addPiece(Color.WHITE, Type.PAWN, "a1");
-                                        addPiece(Color.BLACK, Type.PAWN, "a2");
-
-                                        //when
-                                        //then
-                                        assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a2")))
-                                                .isInstanceOf(IllegalMovePositionException.class);
-                                    }
-                                }
-
-                                @Nested
-                                @DisplayName("목적지에 기물이 없다면")
-                                class IsPieceNotInPosition {
-                                    @Test
-                                    @DisplayName("목적지로 이동한다")
-                                    void moveToPosition() {
-                                        //given
-                                        board.initializeEmpty();
-                                        addPiece(Color.WHITE, Type.PAWN, "a1");
-
-                                        //when
-                                        chessGame.movePiece(new Position("a1"), new Position("a2"));
-
-                                        //then
-                                        assertThat(board.findPiece(new Position("a2")))
-                                                .isEqualTo(createNotBlank(Color.WHITE, Type.PAWN, new Position("a2")));
-                                    }
-                                }
-                            }
-
-                            @Nested
-                            @DisplayName("이동이 대각선이라면")
-                            class IsMoveDiagonal {
-                                @Nested
-                                @DisplayName("목적지에 다른 팀 기물이 있다면")
-                                class IsAnotherTeamPieceInPosition {
-                                    @Test
-                                    @DisplayName("목적지로 이동한다")
-                                    void moveToPosition() {
-                                        board.initializeEmpty();
-                                        addPiece(Color.WHITE, Type.PAWN, "a1");
-                                        addPiece(Color.BLACK, Type.PAWN, "b2");
-
-                                        //when
-                                        chessGame.movePiece(new Position("a1"), new Position("b2"));
-
-                                        //then
-                                        assertThat(board.findPiece(new Position("b2")))
-                                                .isEqualTo(createNotBlank(Color.WHITE, Type.PAWN, new Position("b2")));
-                                    }
-                                }
-
-                                @Nested
-                                @DisplayName("목적지에 다른 팀 기물이 없다면")
-                                class IsAnotherTeamPieceNotInPosition {
-                                    @Test
-                                    @DisplayName("IllegalMovePositionException이 발생한다")
-                                    void throwIllegalMovePositionException() {
-
-                                        //given
-                                        board.initializeEmpty();
-                                        addPiece(Color.WHITE, Type.PAWN, "a1");
-
-                                        //when
-                                        //then
-                                        assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("b2")))
-                                                .isInstanceOf(IllegalMovePositionException.class);
-                                    }
-                                }
-                            }
-                        }
-
-                        @Nested
-                        @DisplayName("기물이 폰이 아니라면")
-                        class IsPieceNotPawn {
-                            @Test
-                            @DisplayName("목적지로 이동한다")
-                            void moveToPosition() {
-                                //given
-                                board.initializeEmpty();
-                                addPiece(Color.WHITE, Type.QUEEN, "a1");
-
-                                //when
-                                chessGame.movePiece(new Position("a1"), new Position("a8"));
-
-                                //then
-                                assertThat(board.findPiece(new Position("a8")))
-                                        .isEqualTo(createNotBlank(Color.WHITE, Type.QUEEN, new Position("a8")));
-                            }
-                        }
-                    }
-                }
-            }
-
-            @Nested
-            @DisplayName("목적지가 기물이 이동할 수 없는 위치라면")
-            class IsPieceCannotMoveToPosition {
+            @DisplayName("목적지가 현재 위치와 동일하다면")
+            class IsDestinationEqualToCurPosition {
                 @Test
                 @DisplayName("IllegalMovePositionException이 발생한다")
                 void throwIllegalMovePositionException() {
@@ -250,9 +96,256 @@ class ChessGameTest {
 
                     //when
                     //then
-
-                    assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("b8")))
+                    assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a1")))
                             .isInstanceOf(IllegalMovePositionException.class);
+                }
+            }
+
+            @Nested
+            @DisplayName("목적지가 현재 위치와 동일하지 않다면")
+            class IsNotDestinationEqualToCurPosition {
+                @Nested
+                @DisplayName("목적지가 기물이 이동할 수 있는 위치라면")
+                class IsPieceCanMoveToDestination {
+                    @Nested
+                    @DisplayName("목적지에 같은 팀 기물이 존재한다면")
+                    class IsSameTeamPieceInDestination {
+                        @Test
+                        @DisplayName("IllegalMovePositionException이 발생한다")
+                        void throwIllegalMovePositionException() {
+                            //given
+                            board.initializeEmpty();
+                            addPiece(Color.WHITE, Type.QUEEN, "a1");
+                            addPiece(Color.WHITE, Type.BISHOP, "a8");
+
+                            //when
+                            //then
+
+                            assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a8")))
+                                    .isInstanceOf(IllegalMovePositionException.class);
+                        }
+                    }
+
+                    @Nested
+                    @DisplayName("목적지에 같은 팀 기물이 존재하지 않다면")
+                    class IsSameTeamPieceNotInDestination {
+
+                        @Nested
+                        @DisplayName("목적지까지 경로에 다른 기물이 존재한다면")
+                        class IsPieceInPath {
+                            @Test
+                            @DisplayName("IllegalMovePositionException이 발생한다")
+                            void throwIllegalMovePositionException() {
+                                //given
+                                board.initializeEmpty();
+                                addPiece(Color.WHITE, Type.QUEEN, "a1");
+                                addPiece(Color.BLACK, Type.PAWN, "a4");
+
+                                //when
+                                //then
+                                assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a8")))
+                                        .isInstanceOf(IllegalMovePositionException.class);
+                            }
+                        }
+
+                        @Nested
+                        @DisplayName("목적지까지 경로에 다른 기물이 존재하지 않는다면")
+                        class IsPieceNotInPath {
+                            @Nested
+                            @DisplayName("기물을 움직였을 때 체크메이트라면")
+                            class IsCheckmateWhenMove {
+                                @Test
+                                @DisplayName("IllegalMovePositionException이 발생한다")
+                                void throwIllegalMovePositionException() {
+                                    //given
+                                    board.initializeEmpty();
+                                    addPiece(Color.WHITE, Type.KING, "a1");
+                                    addPiece(Color.BLACK, Type.ROOK, "b2");
+
+                                    //when
+                                    //then
+                                    assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a2")))
+                                            .isInstanceOf(CheckmateException.class);
+                                }
+                            }
+
+                            @Nested
+                            @DisplayName("체크메이트 상태라면")
+                            class IsCheckmate {
+                                @Nested
+                                @DisplayName("기물을 움직였을 때 체크메이트 경로가 아니라면")
+                                class IsBlockCheckmatePathWhenMove {
+                                    @Test
+                                    @DisplayName("목적지로 이동한다")
+                                    void moveToDestination() {
+                                        //given
+                                        board.initializeEmpty();
+                                        addPiece(Color.WHITE, Type.KING, "a1");
+                                        addPiece(Color.BLACK, Type.ROOK, "a8");
+                                        addPiece(Color.WHITE, Type.ROOK, "b3");
+
+                                        //when
+                                        chessGame.movePiece(new Position("b3"), new Position("a3"));
+
+                                        //then
+                                        assertThat(board.findPiece(new Position("a1")))
+                                                .isEqualTo(createNotBlank(Color.WHITE, Type.KING, new Position("a1")));
+                                    }
+                                }
+
+                                @Nested
+                                @DisplayName("기물을 움직였을 때 체크메이트 기물을 잡는다면")
+                                class IsCatchCheckmatePieceWhenMove {
+                                    @Test
+                                    @DisplayName("목적지로 이동한다")
+                                    void moveToDestination() {
+                                        //given
+                                        board.initializeEmpty();
+                                        addPiece(Color.WHITE, Type.KING, "b1");
+                                        addPiece(Color.WHITE, Type.ROOK, "a2");
+                                        addPiece(Color.BLACK, Type.ROOK, "b2");
+
+                                        //when
+                                        chessGame.movePiece(new Position("a2"), new Position("b2"));
+
+                                        //then
+                                        assertThat(board.findPiece(new Position("b1")))
+                                                .isEqualTo(createNotBlank(Color.WHITE, Type.KING, new Position("b1")));
+                                    }
+                                }
+                            }
+
+                            @Nested
+                            @DisplayName("체크메이트 상태가 아니라면")
+                            class IsNotCheckmate {
+                                @Nested
+                                @DisplayName("기물이 폰이라면")
+                                class IsPiecePawn {
+                                    @Nested
+                                    @DisplayName("이동이 직선이라면")
+                                    class IsMoveLinear {
+                                        @Nested
+                                        @DisplayName("목적지에 기물이 있다면")
+                                        class IsPieceInPosition {
+                                            @Test
+                                            @DisplayName("IllegalMovePositionException이 발생한다")
+                                            void throwIllegalMovePositionException() {
+                                                //given
+                                                board.initializeEmpty();
+                                                addPiece(Color.WHITE, Type.PAWN, "a1");
+                                                addPiece(Color.BLACK, Type.PAWN, "a2");
+
+                                                //when
+                                                //then
+                                                assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("a2")))
+                                                        .isInstanceOf(IllegalMovePositionException.class);
+                                            }
+                                        }
+
+                                        @Nested
+                                        @DisplayName("목적지에 기물이 없다면")
+                                        class IsPieceNotInPosition {
+                                            @Test
+                                            @DisplayName("목적지로 이동한다")
+                                            void moveToDestination() {
+                                                //given
+                                                board.initializeEmpty();
+                                                addPiece(Color.WHITE, Type.KING, "b4");
+                                                addPiece(Color.WHITE, Type.PAWN, "a1");
+
+                                                //when
+                                                chessGame.movePiece(new Position("a1"), new Position("a2"));
+
+                                                //then
+                                                assertThat(board.findPiece(new Position("a2")))
+                                                        .isEqualTo(createNotBlank(Color.WHITE, Type.PAWN, new Position("a2")));
+                                            }
+                                        }
+                                    }
+
+                                    @Nested
+                                    @DisplayName("이동이 대각선이라면")
+                                    class IsMoveDiagonal {
+                                        @Nested
+                                        @DisplayName("목적지에 다른 팀 기물이 있다면")
+                                        class IsAnotherTeamPieceInPosition {
+                                            @Test
+                                            @DisplayName("목적지로 이동한다")
+                                            void moveToDestination() {
+                                                board.initializeEmpty();
+                                                addPiece(Color.WHITE, Type.KING, "b4");
+                                                addPiece(Color.WHITE, Type.PAWN, "a1");
+                                                addPiece(Color.BLACK, Type.PAWN, "b2");
+
+                                                //when
+                                                chessGame.movePiece(new Position("a1"), new Position("b2"));
+
+                                                //then
+                                                assertThat(board.findPiece(new Position("b2")))
+                                                        .isEqualTo(createNotBlank(Color.WHITE, Type.PAWN, new Position("b2")));
+                                            }
+                                        }
+
+                                        @Nested
+                                        @DisplayName("목적지에 다른 팀 기물이 없다면")
+                                        class IsAnotherTeamPieceNotInPosition {
+                                            @Test
+                                            @DisplayName("IllegalMovePositionException이 발생한다")
+                                            void throwIllegalMovePositionException() {
+
+                                                //given
+                                                board.initializeEmpty();
+                                                addPiece(Color.WHITE, Type.PAWN, "a1");
+
+                                                //when
+                                                //then
+                                                assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("b2")))
+                                                        .isInstanceOf(IllegalMovePositionException.class);
+                                            }
+                                        }
+                                    }
+                                }
+
+                                @Nested
+                                @DisplayName("기물이 폰이 아니라면")
+                                class IsPieceNotPawn {
+                                    @Test
+                                    @DisplayName("목적지로 이동한다")
+                                    void moveToDestination() {
+                                        //given
+                                        board.initializeEmpty();
+                                        addPiece(Color.WHITE, Type.KING, "b5");
+                                        addPiece(Color.WHITE, Type.QUEEN, "a1");
+
+                                        //when
+                                        chessGame.movePiece(new Position("a1"), new Position("a8"));
+
+                                        //then
+                                        assertThat(board.findPiece(new Position("a8")))
+                                                .isEqualTo(createNotBlank(Color.WHITE, Type.QUEEN, new Position("a8")));
+                                    }
+                                }
+                            }
+                            }
+                        }
+                }
+
+                @Nested
+                @DisplayName("목적지가 기물이 이동할 수 없는 위치라면")
+                class IsPieceCanNotMoveToDestination {
+                    @Test
+                    @DisplayName("IllegalMovePositionException이 발생한다")
+                    void throwIllegalMovePositionException() {
+                        //given
+                        board.initializeEmpty();
+                        addPiece(Color.WHITE, Type.QUEEN, "a1");
+
+                        //when
+                        //then
+
+                        assertThatThrownBy(() -> chessGame.movePiece(new Position("a1"), new Position("b8")))
+                                .isInstanceOf(IllegalMovePositionException.class);
+                    }
                 }
             }
         }
@@ -287,7 +380,7 @@ class ChessGameTest {
 
     private void addPiece(Color color, Type type, String position) {
         Piece piece = type.equals(Type.NO_PIECE) ?
-                createBlank(new Position(position)): createNotBlank(color, type, new Position(position));
+                createBlank(new Position(position)) : createNotBlank(color, type, new Position(position));
         board.putPiece(new Position(position), piece);
     }
 }

--- a/src/test/java/softeer2nd/chess/ChessViewTest.java
+++ b/src/test/java/softeer2nd/chess/ChessViewTest.java
@@ -24,7 +24,7 @@ class ChessViewTest {
     @DisplayName("showBoard method")
     class ChessBoard {
         @Test
-        @DisplayName("현재 체스판을 출력한다")
+        @DisplayName("현재 체스판의 상태를 나타내는 문자열을 반환한다")
         void printChessBoardCorrect() {
             board.initialize();
 

--- a/src/test/java/softeer2nd/chess/pieces/BlankTest.java
+++ b/src/test/java/softeer2nd/chess/pieces/BlankTest.java
@@ -3,7 +3,7 @@ package softeer2nd.chess.pieces;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import softeer2nd.chess.exception.IllegalMovePieceException;
+import softeer2nd.chess.exception.MoveBlankException;
 
 
 import static org.assertj.core.api.Assertions.*;
@@ -21,7 +21,7 @@ class BlankTest {
 
             //when
             //then
-            assertThatThrownBy(blank::getMovableDirection).isInstanceOf(IllegalMovePieceException.class);
+            assertThatThrownBy(blank::getMovableDirection).isInstanceOf(MoveBlankException.class);
         }
     }
 
@@ -35,7 +35,7 @@ class BlankTest {
             Blank blank = new Blank(new Position("a1"));
             //when
             //then
-            assertThatThrownBy(() -> blank.isMovablePositionByDirection(new Position("a2"), Direction.NNE)).isInstanceOf(IllegalMovePieceException.class);
+            assertThatThrownBy(() -> blank.isMovablePositionByDirection(new Position("a2"), Direction.NNE)).isInstanceOf(MoveBlankException.class);
         }
 
     }
@@ -52,7 +52,7 @@ class BlankTest {
             //when
             //then
             assertThatThrownBy(() -> blank.getMoveDirection(new Position("a2")))
-                    .isInstanceOf(IllegalMovePieceException.class);
+                    .isInstanceOf(MoveBlankException.class);
         }
     }
 
@@ -68,7 +68,7 @@ class BlankTest {
             //when
             //then
             assertThatThrownBy(() -> blank.getMovePath(new Position("a2")))
-                    .isInstanceOf(IllegalMovePieceException.class);
+                    .isInstanceOf(MoveBlankException.class);
         }
     }
 }

--- a/src/test/java/softeer2nd/utils/PositionUtilsTest.java
+++ b/src/test/java/softeer2nd/utils/PositionUtilsTest.java
@@ -3,8 +3,8 @@ package softeer2nd.utils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import softeer2nd.chess.exception.IllegalInputException;
 import softeer2nd.chess.exception.OutOfBoardException;
-import softeer2nd.chess.exception.WrongPositionException;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -52,7 +52,7 @@ class PositionUtilsTest {
                 String[] errorPoses = {"a1b1", "ab"};
                 for (String errorPose : errorPoses) {
                     assertThatThrownBy(() -> PositionUtils.getRankNumFromPosition(errorPose))
-                            .isInstanceOf(WrongPositionException.class);
+                            .isInstanceOf(IllegalInputException.class);
                 }
             }
         }
@@ -101,7 +101,7 @@ class PositionUtilsTest {
                 String[] errorPoses = {"a1b1", "13"};
                 for (String errorPose : errorPoses) {
                     assertThatThrownBy(() -> PositionUtils.getFileNumFromPosition(errorPose))
-                            .isInstanceOf(WrongPositionException.class);
+                            .isInstanceOf(IllegalInputException.class);
                 }
             }
         }


### PR DESCRIPTION
## 구현 내용
- 턴 개념 추가 및 턴 관련 예외 추가
    - 현재 팀과 다른 기물을 움직일 경우 예외 발생
- 킹 이동 제약(규칙) 추가
    - 킹은 상대방 기물들의 도달 가능 경로로 이동하지 못함
- 체크메이트 검증 추가
    - 체크메이트 상태라면 체크메이트 상태를 반드시 해지해야함
## 고민 사항
- 테스트 결과를 한 눈에 보기 쉽도록 "메소드 이름 - <조건들> - 결과"로 하나보니 체스 규칙을 추가하면 할 수록 기물 이동에 관한 메소드의 테스트 결과를 한 눈에 보기 어려워졌습니다. 테스트 코드를 어떻게 수정해야 복잡한 조건에도 한 눈에 결과를 확인할 수 있을지 고민입니다. 
## 기타
비록 프로모션과 캐슬링, 게임 종료 조건은 구현하지 못했지만 대부분의 체스 규칙을 적용에 성공하여 행복합니다 ㅎㅎ.
다른 미션들을 모두 끝내고 시간이 남는다면 프로모션과 캐슬링, 게임 종료 조건까지 구현해보려고 합니다.